### PR TITLE
Building wheels using GitHub Artifacts

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -13,6 +13,7 @@ on:
 
 jobs:
   build:
+    if: github.repository == 'john-science/mazelib'
 
     runs-on: ubuntu-24.04
 

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -35,7 +35,6 @@ jobs:
           pip wheel . -w dist/
           rm dist/Cython*.whl
           rm dist/numpy*.whl
-          auditwheel repair dist/mazelib*.whl -w .
       - name: Archive PIP wheel artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Build Wheels
         run: |
           pip install -U wheel
-          mkdir -f dist
+          mkdir dist
           pip wheel . -w dist/
           rm dist/Cython*.whl
           rm dist/numpy*.whl

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -1,0 +1,44 @@
+name: build wheels
+
+permissions:
+  contents: read
+
+on:
+  push:
+  #  branches:
+  #    - main
+  pull_request:
+  #  branches:
+  #    - main
+
+jobs:
+  build:
+
+    runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.13"
+      - name: Update package index
+        run: sudo apt-get update
+      - name: Install PIP Packages
+        run: |
+          pip install -U pip
+          pip install -e .
+      - name: Build Wheels
+        run: |
+          pip install -U wheel
+          mkdir -f dist
+          pip wheel . -w dist/
+          rm dist/Cython*.whl
+          rm dist/numpy*.whl
+          auditwheel repair dist/mazelib*.whl -w .
+      - name: Archive PIP wheel artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels
+          path: |
+            dist/mazelib*.whl

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -7,10 +7,10 @@ on:
   push:
     branches:
       - main
-  pull_request:
 
 jobs:
   build:
+    if: github.repository == 'john-science/mazelib'
 
     runs-on: ubuntu-24.04
 

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - main
+  pull_request:
 
 jobs:
   build:
@@ -38,3 +39,4 @@ jobs:
           name: mazelib-wheels
           path: |
             dist/mazelib*.whl
+          retention-days: 5

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -5,11 +5,8 @@ permissions:
 
 on:
   push:
-  #  branches:
-  #    - main
-  pull_request:
-  #  branches:
-  #    - main
+    branches:
+      - main
 
 jobs:
   build:
@@ -38,6 +35,6 @@ jobs:
       - name: Archive PIP wheel artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: wheels
+          name: mazelib-wheels
           path: |
             dist/mazelib*.whl

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
-.PHONY: all clean uninstall install benchmark lint test wheel twine
+##########################################
+#    Just a handy set of dev shortcuts   #
+##########################################
+.PHONY: all clean uninstall install lint test benchmark wheel twine
 
 all:
 	@grep -Ee '^[a-z].*:' Makefile | cut -d: -f1 | grep -vF all
@@ -16,14 +19,17 @@ install: uninstall
 	pip install -U pip
 	pip install .
 
-benchmark:
-	python benchmarks/benchmarks.py
+lint:
+	black .
 
 test:
 	python test/test_maze.py
 	python test/test_generators.py
 	python test/test_solvers.py
 	python test/test_transmuters.py
+
+benchmark:
+	python benchmarks/benchmarks.py
 
 wheel:
 	pip install -U pip
@@ -36,6 +42,3 @@ wheel:
 
 twine: wheel
 	twine upload --repository-url https://upload.pypi.org/legacy/ dist/*
-
-lint:
-	black .


### PR DESCRIPTION
Instead of manually generating the wheels, `mazelib` will now automatically generate a new wheel on every commit to the `main` branch using [GitHub Artifacts](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/storing-and-sharing-data-from-a-workflow).

close #144