### PR TITLE
Running tests on a grid

### DIFF
--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -26,8 +26,6 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python }}
-      - name: Update package index
-        run: sudo apt-get update
       - name: Install PIP Packages
         run: |
           pip install -e .

--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -12,9 +12,10 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-24.04
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [ubuntu-24.04, windows-2022, macos-14]
         python: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:

--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -17,6 +17,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        # BEHOLD, our test grid!
         os: [ubuntu-24.04, windows-2022, macos-14]
         python: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 

--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -5,9 +5,11 @@ permissions:
 
 on:
   push:
-    branches:
-      - main
+    paths-ignore:
+      - 'doc/**'
   pull_request:
+    paths-ignore:
+      - 'doc/**'
 
 jobs:
   build:


### PR DESCRIPTION
Trying to run `mazelib` unit test on a grid of 3 Operating Systems, as well as the 6 version of Python. This _should_ yield a grid of 18 different versions of the unit testing.