### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -43,7 +43,7 @@ Again, let's look at the simplest example:
     m.generate_entrances()
     m.solve()
 
-The `BacktrackingSolver` algorithm was choosen to solve the maze. But first, entrances to the maze had to be randomly generated using the helper method `generate_entrances()`. If you prefer, you can manually set the entrances using:
+The `BacktrackingSolver` algorithm was chosen to solve the maze. But first, entrances to the maze had to be randomly generated using the helper method `generate_entrances()`. If you prefer, you can manually set the entrances using:
 
     m.start = (1, 1)
     m.end = (5, 5)

--- a/docs/MAZE_GEN_ALGOS.md
+++ b/docs/MAZE_GEN_ALGOS.md
@@ -173,7 +173,7 @@ perfect
 
 ###### Notes
 
-This algorithm is very flexible. Instead of defining exactly what must be done, it lays out a general construct. The exact order in which we choose a new cell from set C in step 2 is left undefined. That means we can pick one at random (and mimick the Prim's algorithm), or always pick the most recent one (and mimick the Backtracking algorithm). This implementation allows the developer to set the percentage of time Backtracking is chosen versus Prim's. This gives a lot of variety to the final complexity and look of the final maze.
+This algorithm is very flexible. Instead of defining exactly what must be done, it lays out a general construct. The exact order in which we choose a new cell from set C in step 2 is left undefined. That means we can pick one at random (and mimic the Prim's algorithm), or always pick the most recent one (and mimic the Backtracking algorithm). This implementation allows the developer to set the percentage of time Backtracking is chosen versus Prim's. This gives a lot of variety to the final complexity and look of the final maze.
 
 
 ## Hunt-and-Kill

--- a/mazelib/generate/DungeonRooms.py
+++ b/mazelib/generate/DungeonRooms.py
@@ -340,7 +340,7 @@ class DungeonRooms(MazeGenAlgo):
         """Combine sets that have non-zero intersections.
 
         Args:
-            list_of_sets (list): sets of paths that do not interesect
+            list_of_sets (list): sets of paths that do not intersect
         Returns:
             list: a combined collection of paths, now intersection
         """

--- a/mazelib/solve/Collision.py
+++ b/mazelib/solve/Collision.py
@@ -110,7 +110,7 @@ class Collision(MazeSolveAlgo):
         return temp_paths
 
     def _fix_collisions(self, paths):
-        """Look through paths for collsions.
+        """Look through paths for collisions.
         If a collision exists, build a wall in the maze at that point.
 
         Args:

--- a/mazelib/solve/ShortestPath.py
+++ b/mazelib/solve/ShortestPath.py
@@ -82,7 +82,7 @@ class ShortestPath(MazeSolveAlgo):
                         solutions[s].append(self._midpoint(ns[0], solutions[s][-1]))
                         solutions[s].append(ns[0])
                     else:
-                        # there are 2 or 3 valid neigbors
+                        # there are 2 or 3 valid neighbors
                         for j in range(1, len(ns)):
                             nxt = [self._midpoint(ns[j], solutions[s][-1]), ns[j]]
                             solutions.append(list(solutions[s]) + nxt)

--- a/mazelib/solve/ShortestPaths.py
+++ b/mazelib/solve/ShortestPaths.py
@@ -79,7 +79,7 @@ class ShortestPaths(MazeSolveAlgo):
                         solutions[s].append(self._midpoint(ns[0], solutions[s][-1]))
                         solutions[s].append(ns[0])
                     else:
-                        # there are 2 or 3 valid neigbors
+                        # there are 2 or 3 valid neighbors
                         for j in range(1, len(ns)):
                             nxt = [self._midpoint(ns[j], solutions[s][-1]), ns[j]]
                             solutions.append(list(solutions[s]) + nxt)

--- a/mazelib/solve/Tremaux.py
+++ b/mazelib/solve/Tremaux.py
@@ -122,7 +122,7 @@ class Tremaux(MazeSolveAlgo):
                 visit_counts[visit_count] = []
             visit_counts[visit_count].append(neighbor)
 
-        # fullfill the Tremaux rules, using visit counts
+        # fulfill the Tremaux rules, using visit counts
         if 0 in visit_counts:
             # handle the case where we have no choice where to go
             return choice(visit_counts[0])

--- a/mazelib/transmute/CuldeSacFiller.py
+++ b/mazelib/transmute/CuldeSacFiller.py
@@ -18,7 +18,7 @@ class CuldeSacFiller(MazeTransmuteAlgo):
     """
 
     def _transmute(self):
-        """Master methot to fill in all the loops in the maze."""
+        """Master method to fill in all the loops in the maze."""
         for r in range(1, self.grid.shape[0], 2):
             for c in range(1, self.grid.shape[1], 2):
                 if (r, c) in (self.start, self.end):

--- a/mazelib/transmute/Perturbation.py
+++ b/mazelib/transmute/Perturbation.py
@@ -32,7 +32,7 @@ class Perturbation(MazeTransmuteAlgo):
         super(Perturbation, self).__init__()
 
     def _transmute(self):
-        """Primary method to slightly pertub the maze a set number of times."""
+        """Primary method to slightly perturb the maze a set number of times."""
         for i in range(self.repeat):
             # Add a small number of random walls, blocking current passages
             for j in range(self.new_walls):

--- a/test/test_maze.py
+++ b/test/test_maze.py
@@ -183,7 +183,7 @@ class MazeTest(unittest.TestCase):
         m.generator = Prims(3, 3)
         self.assertRaises(AssertionError, m.solve)
 
-        # the pretty-print, sring formats should fail gracefully
+        # the pretty-print, string formats should fail gracefully
         m.start = (1, 1)
         m.end = (3, 3)
         assert str(m) == ""

--- a/test/test_solvers.py
+++ b/test/test_solvers.py
@@ -184,7 +184,7 @@ class SolversTest(unittest.TestCase):
         assert sol == m.solver._prune_solution(sol * 100)
 
     def test_backtracking_solver(self):
-        """Test BacktrackingSolver against a maze with outer/inner entraces."""
+        """Test BacktrackingSolver against a maze with outer/inner entrances."""
         starts = [True, False]
         ends = [True, False]
 
@@ -203,7 +203,7 @@ class SolversTest(unittest.TestCase):
                     assert self.solution_is_sane(sol)
 
     def test_chain(self):
-        """Test against a maze with outer/inner entraces."""
+        """Test against a maze with outer/inner entrances."""
         starts = [True, False]
         ends = [True, False]
 
@@ -222,7 +222,7 @@ class SolversTest(unittest.TestCase):
                     assert self.solution_is_sane(sol)
 
     def test_collision(self):
-        """Test against a maze with outer/inner entraces."""
+        """Test against a maze with outer/inner entrances."""
         starts = [True, False]
         ends = [True, False]
 
@@ -241,7 +241,7 @@ class SolversTest(unittest.TestCase):
                     assert self.solution_is_sane(sol)
 
     def test_random_mouse(self):
-        """Test against a maze with outer/inner entraces."""
+        """Test against a maze with outer/inner entrances."""
         starts = [True, False]
         ends = [True, False]
 
@@ -260,7 +260,7 @@ class SolversTest(unittest.TestCase):
                     assert self.solution_is_sane(sol)
 
     def test_shortest_path(self):
-        """Test against a maze with outer/inner entraces."""
+        """Test against a maze with outer/inner entrances."""
         starts = [True, False]
         ends = [True, False]
 
@@ -279,7 +279,7 @@ class SolversTest(unittest.TestCase):
                     assert self.solution_is_sane(sol)
 
     def test_shortest_paths(self):
-        """Test against a maze with outer/inner entraces."""
+        """Test against a maze with outer/inner entrances."""
         starts = [True, False]
         ends = [True, False]
 
@@ -298,7 +298,7 @@ class SolversTest(unittest.TestCase):
                     assert self.solution_is_sane(sol)
 
     def test_tremaux(self):
-        """Test against a maze with outer/inner entraces."""
+        """Test against a maze with outer/inner entrances."""
         starts = [True, False]
         ends = [True, False]
 


### PR DESCRIPTION
% `codespell ` # https://pypi.org/project/codespell
```
./test/test_maze.py:186: sring ==> string
./test/test_solvers.py:187: entraces ==> entrances
./test/test_solvers.py:206: entraces ==> entrances
./test/test_solvers.py:225: entraces ==> entrances
./test/test_solvers.py:244: entraces ==> entrances
./test/test_solvers.py:263: entraces ==> entrances
./test/test_solvers.py:282: entraces ==> entrances
./test/test_solvers.py:301: entraces ==> entrances
./mazelib/solve/Collision.py:113: collsions ==> collisions
./mazelib/solve/ShortestPath.py:85: neigbors ==> neighbors
./mazelib/solve/ShortestPaths.py:82: neigbors ==> neighbors
./mazelib/solve/Tremaux.py:125: fullfill ==> fulfill, fulfil
./mazelib/generate/DungeonRooms.py:343: interesect ==> intersect
./mazelib/transmute/CuldeSacFiller.py:21: methot ==> method
./mazelib/transmute/Perturbation.py:35: pertub ==> perturb
./docs/API.md:46: choosen ==> chosen
./docs/MAZE_GEN_ALGOS.md:176: mimick ==> mimic
./docs/MAZE_GEN_ALGOS.md:176: mimick ==> mimic
```
% `codespell --write-changes`