### PR TITLE
ruff v0.11.2 and rules C4,PERF,UP032,UP034

### DIFF
--- a/benchmarks.py
+++ b/benchmarks.py
@@ -78,8 +78,8 @@ def print_benchmarks(times):
     """
     print("\nmazelib benchmarking")
     print(datetime.now().strftime("%Y-%m-%d %H:%M"))
-    print("Python version: {0}".format(get_python_version()))
-    print("mazelib version: {0}".format(version))
+    print(f"Python version: {get_python_version()}")
+    print(f"mazelib version: {version}")
     print(
         "\nTotal Time (seconds): %.5f\n" % sum([sum(times_row) for times_row in times])
     )

--- a/mazelib/generate/Kruskal.py
+++ b/mazelib/generate/Kruskal.py
@@ -31,13 +31,15 @@ class Kruskal(MazeGenAlgo):
                 forest.append([(row, col)])
                 grid[row][col] = 0
 
-        edges = []
-        for row in range(2, self.H - 1, 2):
-            for col in range(1, self.W - 1, 2):
-                edges.append((row, col))
-        for row in range(1, self.H - 1, 2):
-            for col in range(2, self.W - 1, 2):
-                edges.append((row, col))
+        edges = [
+            (row, col)
+            for row in range(2, self.H - 1, 2)
+            for col in range(1, self.W - 1, 2)
+        ] + [
+            (row, col)
+            for row in range(1, self.H - 1, 2)
+            for col in range(2, self.W - 1, 2)
+        ]
 
         shuffle(edges)
 

--- a/mazelib/mazelib.py
+++ b/mazelib/mazelib.py
@@ -218,9 +218,7 @@ class Maze:
             return ""
 
         # build the walls of the grid
-        txt = []
-        for row in self.grid:
-            txt.append("".join(["#" if cell else " " for cell in row]))
+        txt = ["".join("#" if cell else " " for cell in row) for row in self.grid]
 
         # insert the start and end points
         if entrances and self.start and self.end:

--- a/mazelib/solve/ShortestPath.py
+++ b/mazelib/solve/ShortestPath.py
@@ -91,7 +91,7 @@ class ShortestPath(MazeSolveAlgo):
 
             # 3) a solution reaches the end or a dead end when we mark it by appending a None.
             num_unfinished = sum(
-                map(lambda sol: 0 if sol[-1] is None else 1, solutions)
+                0 if sol[-1] is None else 1 for sol in solutions
             )
 
         # 4) clean-up solutions

--- a/mazelib/solve/ShortestPaths.py
+++ b/mazelib/solve/ShortestPaths.py
@@ -88,7 +88,7 @@ class ShortestPaths(MazeSolveAlgo):
 
             # 3) a solution reaches the end or a dead end when we mark it by appending a None.
             num_unfinished = sum(
-                map(lambda sol: 0 if sol[-1] is None else 1, solutions)
+                0 if sol[-1] is None else 1 for sol in solutions
             )
 
         # 4) clean-up solutions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ classifiers = [
 [project.optional-dependencies]
 dev = [
     "black == 24.10.0",
-    "ruff == 0.7.4",
+    "ruff == 0.11.2",
     "toml == 0.10.2",
     "twine == 4.0.2",
 ]
@@ -62,7 +62,7 @@ readme = {file = ["README.md"]}
 #######################################################################
 [tool.ruff]
 # This is the exact version of Ruff we use.
-required-version = "0.7.4"
+required-version = "0.11.2"
 
 # Assume Python 3.13
 target-version = "py313"
@@ -98,11 +98,13 @@ exclude = [
 
 [tool.ruff.lint]
 # Enable pycodestyle (E) and Pyflakes (F) codes by default.
+# C4 - flake8-comprehensions
 # D - NumPy docstring rules
 # N801 - Class name should use CapWords convention
+# PERF - Perflint
 # SIM - code simplification rules
 # TID - tidy imports
-select = ["E", "F", "D", "N801", "SIM", "TID"]
+select = ["E", "F", "C4", "D", "N801", "PERF", "SIM", "TID"]
 
 # Ruff rules we ignore (for now) because they are not 100% automatable
 #
@@ -142,4 +144,3 @@ ban-relative-imports = "all"
 
 [tool.ruff.lint.pydocstyle]
 convention = "numpy"
-


### PR DESCRIPTION
% `uvx ruff==0.7.4 check --select="C4,PERF,UP032,UP034" --statistics | sort -k2`
```
2	C417   	[*] unnecessary-map
3	PERF401	[ ] manual-list-comprehension
2	UP032  	[*] f-string
[*] fixable with `ruff check --fix`
```